### PR TITLE
DumpHandler: handle <page> tags with multiple <revision> entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ pages = DumpReader().read(dump)
 ['Main Page', 'Brúkari:Jon Harald Søby', 'Forsíða', 'Ormurin Langi', 'Regin smiður', 'Fyrimynd:InterLingvLigoj', 'Heimsyvirlýsingin um mannarættindi', 'Bólkur:Kvæði', 'Bólkur:Yrking', 'Kjak:Forsíða']
 ```
 
-You can read article pages only as well:
+`read` method yields the following per-revision information: `namespace`, `page_id`, `title`, `content`, `revision_id`, `timestamp`, `contributor` (`None` for anonymous edits).
+
+By using `DumpReaderArticles` class you can read article pages only:
 
 ```python
 import logging; logging.basicConfig(level=logging.INFO)

--- a/test/fixtures/dump.xml
+++ b/test/fixtures/dump.xml
@@ -1,0 +1,29 @@
+<mediawiki xml:lang="en">
+    <page>
+      <title>Page title</title>
+      <restrictions>edit=sysop:move=sysop</restrictions>
+      <revision>
+        <timestamp>2001-01-15T13:15:00Z</timestamp>
+        <contributor><username>Foobar</username></contributor>
+        <comment>I have just one thing to say!</comment>
+        <text>A bunch of [[Special:MyLanguage/text|text]] here.</text>
+        <minor />
+      </revision>
+      <revision>
+        <timestamp>2001-01-15T13:10:27Z</timestamp>
+        <contributor><ip>10.0.0.2</ip></contributor>
+        <comment>new!</comment>
+        <text>An earlier [[Special:MyLanguage/revision|revision]].</text>
+      </revision>
+    </page>
+
+    <page>
+      <title>Talk:Page title</title>
+      <revision>
+        <timestamp>2001-01-15T14:03:00Z</timestamp>
+        <contributor><ip>10.0.0.2</ip></contributor>
+        <comment>hey</comment>
+        <text>WHYD YOU LOCK PAGE??!!! i was editing that jerk</text>
+      </revision>
+    </page>
+  </mediawiki>

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -42,7 +42,7 @@ def test_wikipedia():
     pages = list(reader.read(dump))
 
     assert len(pages) == 2, "Dump has two items"
-    assert len(pages[0]) == 6, "Each item has six members"
+    assert len(pages[0]) == 7, "Each item has seven members"
 
     assert pages[0][0] == 8  # ns
     assert pages[0][1] == 121  # page_id
@@ -50,6 +50,7 @@ def test_wikipedia():
     assert str(pages[0][3]).startswith('Tú hevur nú ritað út.')   # content
     assert pages[0][4] == 18683  # revision ID
     assert pages[0][5] == 1146089189  # revision UNIX timestamp
+    assert pages[0][6] == 'Quackor'  # author
 
     assert pages[1][0] == 0  # ns
     assert pages[1][1] == 2201  # page_id
@@ -57,6 +58,7 @@ def test_wikipedia():
     assert str(pages[1][3]).startswith('{{Infoboks Kommuna|\nnavn              = Klaksvíkar kommuna|')   # content
     assert pages[1][4] == 341301  # revision ID
     assert pages[1][5] == 1478696410  # revision UNIX timestamp
+    assert pages[1][6] == 'EileenSanda'  # author
 
 
 def test_wikia():
@@ -67,7 +69,7 @@ def test_wikia():
     print(pages)
 
     assert len(pages) == 3, "Dump has three items"
-    assert len(pages[0]) == 6, "Each item has six members"
+    assert len(pages[0]) == 7, "Each item has seven members"
 
     assert pages[0][0] == 14  # ns
     assert pages[0][1] == 1  # page_id
@@ -75,6 +77,7 @@ def test_wikia():
     assert str(pages[0][3]).startswith('The main category for this community')   # content
     assert pages[0][4] == 1  # revision ID
     assert pages[0][5] == 1476301866  # revision UNIX timestamp
+    assert pages[0][6] == 'Default'  # author
 
     assert pages[1][0] == 0  # ns
     assert pages[1][1] == 2  # page_id
@@ -82,6 +85,7 @@ def test_wikia():
     assert pages[1][3] == '123\n[[Category:Browse]]'   # content
     assert pages[1][4] == 338  # revision ID
     assert pages[1][5] == 1520427072  # revision UNIX timestamp
+    assert pages[1][6] == 'Macbre'  # author
 
 
 def test_wikia_content_pages():
@@ -105,9 +109,12 @@ def test_plain_dump():
 
     assert pages[0][2] == 'Page title'  # title
     assert pages[0][5] == 979564500  # revision UNIX timestamp
+    assert pages[0][6] == 'Foobar'  # author
 
     assert pages[1][2] == 'Page title'  # title
     assert pages[1][5] == 979564227  # revision UNIX timestamp
+    assert pages[1][6] == 'Foobar'  # author
 
     assert pages[2][2] == 'Talk:Page title'  # title
     assert pages[2][5] == 979567380  # revision UNIX timestamp
+    assert pages[2][6] is None  # an anonymous contributor

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -24,6 +24,17 @@ class WikiaDumpFixture(WikiaDump):
         return open('test/fixtures/dump.xml.7z', 'rb')
 
 
+class PlainDumpFixture(WikiaDump):
+    def __init__(self):
+        super(PlainDumpFixture, self).__init__('')
+
+    def get_url(self):
+        pass
+
+    def get_content(self):
+        return open('test/fixtures/dump.xml', 'rt')
+
+
 def test_wikipedia():
     dump = WikipediaDumpFixture()
     reader = DumpReader()
@@ -81,3 +92,22 @@ def test_wikia_content_pages():
     print(pages)
 
     assert len(pages) == 1, "There is only one content pages in the dump"
+
+
+def test_plain_dump():
+    dump = PlainDumpFixture()
+    reader = DumpReaderArticles()
+
+    pages = list(reader.read(dump))
+    print(pages)
+
+    assert len(pages) == 3, "There are three entries in the dump, but only two pages"
+
+    assert pages[0][2] == 'Page title'  # title
+    assert pages[0][5] == 979564500  # revision UNIX timestamp
+
+    assert pages[1][2] == 'Page title'  # title
+    assert pages[1][5] == 979564227  # revision UNIX timestamp
+
+    assert pages[2][2] == 'Talk:Page title'  # title
+    assert pages[2][5] == 979567380  # revision UNIX timestamp


### PR DESCRIPTION
```xml
<mediawiki xml:lang="en">
    <page>
      <title>Page title</title>
      <restrictions>edit=sysop:move=sysop</restrictions>
      <revision>
        <timestamp>2001-01-15T13:15:00Z</timestamp>
        <contributor><username>Foobar</username></contributor>
        <comment>I have just one thing to say!</comment>
        <text>A bunch of [[Special:MyLanguage/text|text]] here.</text>
        <minor />
      </revision>
      <revision>
        <timestamp>2001-01-15T13:10:27Z</timestamp>
        <contributor><ip>10.0.0.2</ip></contributor>
        <comment>new!</comment>
        <text>An earlier [[Special:MyLanguage/revision|revision]].</text>
      </revision>
    </page>

    <page>
      <title>Talk:Page title</title>
      <revision>
        <timestamp>2001-01-15T14:03:00Z</timestamp>
        <contributor><ip>10.0.0.2</ip></contributor>
        <comment>hey</comment>
        <text>WHYD YOU LOCK PAGE??!!! i was editing that jerk</text>
      </revision>
    </page>
  </mediawiki>
```