### PR TITLE
parse_date_string: return datetime instance instead of a UNIX timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 pip install mediawiki_dump
 ```
 
-[Python package](https://pypi.org/project/mediawiki_dump/) for working with [MediaWiki XML content dumps](https://www.mediawiki.org/wiki/Manual:Backing_up_a_wiki#Backup_the_content_of_the_wiki_(XML_dump)).
+[Python3 package](https://pypi.org/project/mediawiki_dump/) for working with [MediaWiki XML content dumps](https://www.mediawiki.org/wiki/Manual:Backing_up_a_wiki#Backup_the_content_of_the_wiki_(XML_dump)).
 
 Wikipedia (bz2 compressed) and Wikia (7zip) content dumps are supported.
 

--- a/README.md
+++ b/README.md
@@ -122,31 +122,31 @@ from mediawiki_dump.reader import DumpReaderArticles
 dump = WikiaDump('macbre', full_history=True)  # fetch full history, including old revisions
 pages = DumpReaderArticles().read(dump)
 
-print('\n'.join(['%d %s (%s)' % (timestamp, title, author) for _, _, title, _, _, timestamp, author in pages]))
+print('\n'.join(['%s %s (%s)' % (str(timestamp), title, author) for _, _, title, _, _, timestamp, author in pages]))
 ```
 
 Will give you:
 
 ```
 INFO:DumpReaderArticles:Parsing completed, entries found: 384
-1476301866 Macbre Wiki (Default)
-1476301865 Macbre Wiki (Wikia)
-1478255600 Macbre Wiki (Macbre)
-1478255837 Macbre Wiki (FandomBot)
-1485355657 Macbre Wiki (FandomBot)
-1491823225 Macbre Wiki (Ryba777)
-1491823280 Macbre Wiki (Ryba777)
-1520427072 Macbre Wiki (Macbre)
-1476301865 Main Page (Wikia)
-1478600133 FooBar (None)
-1478600149 FooBar (None)
+2016-10-12 19:51:06+00:00 Macbre Wiki (Default)
+2016-10-12 19:51:05+00:00 Macbre Wiki (Wikia)
+2016-11-04 10:33:20+00:00 Macbre Wiki (Macbre)
+2016-11-04 10:37:17+00:00 Macbre Wiki (FandomBot)
+2017-01-25 14:47:37+00:00 Macbre Wiki (FandomBot)
+2017-04-10 11:20:25+00:00 Macbre Wiki (Ryba777)
+2017-04-10 11:21:20+00:00 Macbre Wiki (Ryba777)
+2018-03-07 12:51:12+00:00 Macbre Wiki (Macbre)
+2016-10-12 19:51:05+00:00 Main Page (Wikia)
+2016-11-08 10:15:33+00:00 FooBar (None)
+2016-11-08 10:15:49+00:00 FooBar (None)
 ...
-1528199144 YouTube tag (FANDOMbot)
-1528275084 Maps (Macbre)
-1528359433 Maps (Macbre)
-1528359456 Maps (Macbre)
-1532443940 Scary transclusion (Macbre)
-1536674655 Lua (Macbre)
-1536675264 Lua (Macbre)
-1536675277 Lua (Macbre)
+2018-06-05 11:45:44+00:00 YouTube tag (FANDOMbot)
+2018-06-06 08:51:24+00:00 Maps (Macbre)
+2018-06-07 08:17:13+00:00 Maps (Macbre)
+2018-06-07 08:17:36+00:00 Maps (Macbre)
+2018-07-24 14:52:20+00:00 Scary transclusion (Macbre)
+2018-09-11 14:04:15+00:00 Lua (Macbre)
+2018-09-11 14:14:24+00:00 Lua (Macbre)
+2018-09-11 14:14:37+00:00 Lua (Macbre)
 ```

--- a/mediawiki_dump/reader.py
+++ b/mediawiki_dump/reader.py
@@ -7,7 +7,7 @@ import logging
 
 from xml import sax
 
-from .utils import datetime_to_timestamp
+from .utils import parse_date_string
 
 
 class DumpHandler(sax.ContentHandler):
@@ -206,7 +206,7 @@ class DumpReader:
 
                 if self.filter_by_namespace(namespace):
                     # parse "2004-05-25T02:19:28Z" to UNIX timestamp (in UTC)
-                    timestamp = datetime_to_timestamp(revision_timestamp)
+                    timestamp = parse_date_string(revision_timestamp)
 
                     yield namespace, page_id, title, content, revision_id, timestamp, contributor
 

--- a/mediawiki_dump/utils.py
+++ b/mediawiki_dump/utils.py
@@ -4,11 +4,11 @@ Utility functions
 from datetime import datetime, timezone
 
 
-def datetime_to_timestamp(date):
+def parse_date_string(date):
     """
     Converts date as string (e.g. "2004-05-25T02:19:28Z") to UNIX timestamp (uses UTC, always)
     :type date str
-    :rtype: int
+    :rtype: datetime
     """
 
     # https://docs.python.org/3.6/library/datetime.html#strftime-strptime-behavior
@@ -16,4 +16,4 @@ def datetime_to_timestamp(date):
     parsed = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')  # string parse time
 
     # now apply UTC timezone
-    return int(parsed.replace(tzinfo=timezone.utc).timestamp())
+    return parsed.replace(tzinfo=timezone.utc)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from setuptools import setup, find_packages
 
 VERSION = '0.2'
 
+# @see https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 # @see https://github.com/pypa/sampleproject/blob/master/setup.py
 setup(
     name='mediawiki_dump',
@@ -10,6 +14,9 @@ setup(
     author_email='maciej.brencz@gmail.com',
     license='MIT',
     description='Python package for working with MediaWiki XML content dumps',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    keywords='dump fandom mediawiki wikipedia wikia',
     url='https://github.com/macbre/mediawiki_dump',
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'dev': [
             'coverage==4.5.1',
             'pylint==2.1.1',
-            'pytest==3.9.2',
+            'pytest==3.9.3',
         ]
     },
     install_requires=[

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -49,7 +49,7 @@ def test_wikipedia():
     assert pages[0][2] == 'MediaWiki:Logouttext'  # title
     assert str(pages[0][3]).startswith('Tú hevur nú ritað út.')   # content
     assert pages[0][4] == 18683  # revision ID
-    assert pages[0][5] == 1146089189  # revision UNIX timestamp
+    assert pages[0][5].timestamp() == 1146089189  # revision UNIX timestamp
     assert pages[0][6] == 'Quackor'  # author
 
     assert pages[1][0] == 0  # ns
@@ -57,7 +57,7 @@ def test_wikipedia():
     assert pages[1][2] == 'Klaksvíkar kommuna'  # title
     assert str(pages[1][3]).startswith('{{Infoboks Kommuna|\nnavn              = Klaksvíkar kommuna|')   # content
     assert pages[1][4] == 341301  # revision ID
-    assert pages[1][5] == 1478696410  # revision UNIX timestamp
+    assert pages[1][5].timestamp() == 1478696410  # revision UNIX timestamp
     assert pages[1][6] == 'EileenSanda'  # author
 
 
@@ -76,7 +76,7 @@ def test_wikia():
     assert pages[0][2] == 'Kategoria:Browse'  # title
     assert str(pages[0][3]).startswith('The main category for this community')   # content
     assert pages[0][4] == 1  # revision ID
-    assert pages[0][5] == 1476301866  # revision UNIX timestamp
+    assert pages[0][5].timestamp() == 1476301866  # revision UNIX timestamp
     assert pages[0][6] == 'Default'  # author
 
     assert pages[1][0] == 0  # ns
@@ -84,7 +84,7 @@ def test_wikia():
     assert pages[1][2] == 'Macbre Wiki'  # title
     assert pages[1][3] == '123\n[[Category:Browse]]'   # content
     assert pages[1][4] == 338  # revision ID
-    assert pages[1][5] == 1520427072  # revision UNIX timestamp
+    assert pages[1][5].timestamp() == 1520427072  # revision UNIX timestamp
     assert pages[1][6] == 'Macbre'  # author
 
 
@@ -108,13 +108,13 @@ def test_plain_dump():
     assert len(pages) == 3, "There are three entries in the dump, but only two pages"
 
     assert pages[0][2] == 'Page title'  # title
-    assert pages[0][5] == 979564500  # revision UNIX timestamp
+    assert pages[0][5].timestamp() == 979564500  # revision UNIX timestamp
     assert pages[0][6] == 'Foobar'  # author
 
     assert pages[1][2] == 'Page title'  # title
-    assert pages[1][5] == 979564227  # revision UNIX timestamp
+    assert pages[1][5].timestamp() == 979564227  # revision UNIX timestamp
     assert pages[1][6] == 'Foobar'  # author
 
     assert pages[2][2] == 'Talk:Page title'  # title
-    assert pages[2][5] == 979567380  # revision UNIX timestamp
+    assert pages[2][5].timestamp() == 979567380  # revision UNIX timestamp
     assert pages[2][6] is None  # an anonymous contributor

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,9 @@
-from mediawiki_dump.utils import datetime_to_timestamp
+from mediawiki_dump.utils import parse_date_string
 
 
-def test_datetime_to_timestamp():
+def test_parse_date_string():
     # new Date(1085451568000).toGMTString()
     # "Tue, 25 May 2004 02:19:28 GMT"
-    assert datetime_to_timestamp('1970-01-01T00:00:00Z') == 0
-    assert datetime_to_timestamp('2004-05-25T02:19:28Z') == 1085451568
-    assert datetime_to_timestamp('2018-10-29T16:01:01Z') == 1540828861
+    assert parse_date_string('1970-01-01T00:00:00Z').timestamp() == 0
+    assert parse_date_string('2004-05-25T02:19:28Z').timestamp() == 1085451568
+    assert parse_date_string('2018-10-29T16:01:01Z').timestamp() == 1540828861


### PR DESCRIPTION
* update `pytest`
* `setup.py` - use `README.md` as `long_description`