### PR TITLE
Do not be so strict on pinned depedencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,14 +43,14 @@ setup(
     packages=find_packages(),
     extras_require={
         'dev': [
-            'coverage==4.5.3',
-            'pylint==2.3.1',
-            'pytest==5.0.1',
+            'coverage>=4.5.3',
+            'pylint>=2.3.1',
+            'pytest>=5.0.1',
         ]
     },
     install_requires=[
-        'libarchive-c==2.8',
-        'requests==2.22.0',
-        'mwclient==0.9.3',
+        'libarchive-c>=2.8',
+        'requests>=2.22.0',
+        'mwclient>=0.9.3',
     ]
 )


### PR DESCRIPTION
Hello,

Is it something you would be interested in? I mean, as a third-party module, the requirements are too strict IMO. For instance, using an up-to-date `requests` version will output:
```shell
ERROR: mediawiki-dump 0.6.7 has requirement requests==2.22.0, but you'll have requests 2.23.0 which is incompatible.
```