### PR TITLE
Report code coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
       run: make lint
 
     - name: Test with pytest
-      run: make test
+      run: make coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,11 @@ jobs:
 
     - name: Test with pytest
       run: make coverage
+
+    # https://coveralls-python.readthedocs.io/en/latest/usage/index.html
+    # upload coverage report for just one of Python version matrix runs
+    - name: Upload coverage report to Coveralls
+      if: matrix.python-version == '3.9'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: coveralls --service=github

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ lint:
 	pylint mediawiki_dump
 
 coverage:
-	pytest --cov=mediawiki_dump --cov-report=term --cov-report=xml --cov-fail-under=91 -vv
+	pytest --cov=mediawiki_dump --cov-report=term --cov-report=xml --cov-report=html --cov-fail-under=91 -vv
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-coverage_options = --include='mediawiki_dump/*' --omit='test/*'
-
 init:
 	pip install -e .[dev]
 
@@ -10,17 +8,6 @@ lint:
 	pylint mediawiki_dump
 
 coverage:
-	rm -f .coverage*
-	rm -rf htmlcov/*
-	coverage run -p -m pytest -v
-	coverage combine
-	coverage html -d htmlcov $(coverage_options)
-	coverage xml -i
-	coverage report $(coverage_options)
-
-publish:
-	# run git tag -a v0.0.0 before running make publish
-	python setup.py sdist
-	twine upload dist/*
+	pytest --cov=mediawiki_dump --cov-report=term --cov-report=xml --cov-fail-under=91 -vv
 
 .PHONY: test

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,10 @@ setup(
     extras_require={
         "dev": [
             "black==21.8b0",
-            "coverage==5.5",
+            "coveralls==3.2.0",
             "pylint==2.10.2",
             "pytest==6.2.4",
+            "pytest-cov==2.12.1",
         ]
     },
     install_requires=[


### PR DESCRIPTION
* use `pytest-cov`
* threshold set to 91%
* report code coverage to Coveralls
----

```
----------- coverage: platform linux, python 3.9.6-final-0 -----------
Name                          Stmts   Miss  Cover
-------------------------------------------------
mediawiki_dump/__init__.py        0      0   100%
mediawiki_dump/dumps.py         106     27    75%
mediawiki_dump/entry.py          18      0   100%
mediawiki_dump/reader.py        137      1    99%
mediawiki_dump/tokenizer.py      47      0   100%
mediawiki_dump/utils.py           4      0   100%
-------------------------------------------------
TOTAL                           312     28    91%
```