### PR TITLE
Fix issue with cleaning links with namespace and label

### DIFF
--- a/mediawiki_dump/tokenizer.py
+++ b/mediawiki_dump/tokenizer.py
@@ -57,8 +57,8 @@ def clean(text: str) -> str:
         flags=re.MULTILINE,
     )  # == a == -> a
 
-    # files and other links with namespaces
-    text = re.sub(r"\[\[[^:\]]+:[^\]]+\]\]", "", text)  # [[foo:b]] -> ''
+    # files and other links with namespaces (but without labels)
+    text = re.sub(r"\[\[[^:\]]+:[^\]|]+\]\]", "", text)  # [[foo:b]] -> ''
 
     # local links
     text = re.sub(r"\[\[([^|\]]+)\]\]", "\\1", text)  # [[a]] -> a


### PR DESCRIPTION
I was using this repository to process a dump from uesp.net, but ran into an issue with links not being replaced with their labels correctly.

Given, for example:
```
Welcome to the [[UESPWiki:About|Unofficial Elder Scrolls Pages]]!
```

It would be cleaned to:
```
Welcome to the !
```

I tracked the issue down to the 'links with namespaces' regex substitution being a little overinclusive.

I modified the part of the regex after it finds the `:` to fail if there is a label (`|`) on the link. This way the `re.sub` a few lines later that replaces local links with their labels will also replace this link with its label.

This results in the expected cleaned output of:
```
Welcome to the Unofficial Elder Scrolls Pages!
```