### PR TITLE
Introduce the IteratorDump for reading the XML dump as a stream

### DIFF
--- a/mediawiki_dump/dumps.py
+++ b/mediawiki_dump/dumps.py
@@ -195,7 +195,7 @@ class IteratorDump(BaseDump):
         yield from self.iterator
 
 
-class LocalFileDump(BaseDump):
+class LocalFileDump(IteratorDump):
     """
     This class can be used to load locally stored XML dump file
     """
@@ -208,9 +208,9 @@ class LocalFileDump(BaseDump):
         pass
 
     def get_content(self):
-        """Yields processed pieces of content"""
-        # pylint:disable=consider-using-with
-        return open(self.dump_file, mode="rt", encoding="utf-8")
+        with open(self.dump_file, mode="rb") as fp:
+            self.iterator = fp
+            yield from super().get_content()
 
 
 class StringDump(BaseDump):

--- a/mediawiki_dump/dumps.py
+++ b/mediawiki_dump/dumps.py
@@ -178,6 +178,23 @@ class WikiaDump(BaseDump):
                     yield from entry.get_blocks()
 
 
+class IteratorDump(BaseDump):
+    """
+    This class can be used to pass the XML dump via an iterator,
+    for instance when streaming and decompressing a local file.
+    """
+
+    def __init__(self, iterator: iter):
+        super().__init__(wiki="")
+        self.iterator = iterator
+
+    def get_url(self):
+        pass
+
+    def get_content(self):
+        yield from self.iterator
+
+
 class LocalFileDump(BaseDump):
     """
     This class can be used to load locally stored XML dump file

--- a/test/test_local_file_dump.py
+++ b/test/test_local_file_dump.py
@@ -1,5 +1,7 @@
+import bz2
 import pytest
-from mediawiki_dump.dumps import LocalFileDump
+
+from mediawiki_dump.dumps import LocalFileDump, IteratorDump
 from mediawiki_dump.reader import DumpReader
 
 
@@ -16,3 +18,17 @@ def test_read_local_file():
     assert reader.get_dump_language() == "en"
     assert reader.get_base_url() == "https://pl.wikipedia.org/wiki/"
     assert reader.handler.get_siteinfo().get("dbname", None) == "plwiki"
+
+
+def test_read_compressed_local_file_as_stream():
+    def get_content(file_name: str):
+        with bz2.open(file_name, mode="r") as fp:
+            yield from fp
+
+    dump = IteratorDump(iterator=get_content(file_name="test/fixtures/dump.xml.bz2"))
+    reader = DumpReader()
+
+    pages = [entry.title for entry in reader.read(dump)]
+    print(pages)
+
+    assert pages == ["MediaWiki:Logouttext", "Klaksvíkar kommuna"]


### PR DESCRIPTION
The new `IteratorDump` class can used with an iterator - for instance when streaming and decompressing a local file / HTTP response.

/cc @fenopa