### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/test/test_dumps.py
+++ b/test/test_dumps.py
@@ -119,7 +119,8 @@ def test_fetch_via_mocked_http():
     # skip file-based caching in BaseDump cache
     # https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch
     with patch("mediawiki_dump.dumps.isfile", return_value=False) as mocked_method:
-        body = open("test/fixtures/dump.xml.bz2", "rb").read()
+        with open("test/fixtures/dump.xml.bz2", "rb") as f:
+            body = f.read()
 
         with get_dump_with_mocked_http_response(body=body, status=200) as dump:
             body = "".join(


### PR DESCRIPTION
This pull request fixes a file-handling issue in the tests. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python's garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.